### PR TITLE
Release feature for private endpoints and CW log group

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ module "vpc" {
   one_nat_gateway_per_az                          = true
   database_subnet_enabled                         = true
   vpn_server_instance_type                        = "t3a.small"
+  vpc_s3_endpoint_enabled                         = true
+  vpc_ecr_endpoint_enabled                        = true
   flow_log_max_aggregation_interval               = 60
+  flow_log_cloudwatch_log_group_skip_destroy      = true
   flow_log_cloudwatch_log_group_retention_in_days = 90
   flow_log_cloudwatch_log_group_kms_key_arn       = "arn:aws:kms:us-east-2:222222222222:key/kms_key_arn" #Enter your kms key arn
 }
@@ -200,18 +203,23 @@ In this module, we have implemented the following CIS Compliance checks for VPC:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.1.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.2.0 |
 | <a name="module_vpn_server"></a> [vpn\_server](#module\_vpn\_server) | ./modules/vpn | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_endpoint.private-ecr-api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.private-ecr-dkr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.private-s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_ipam.ipam](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam) | resource |
 | [aws_vpc_ipam_pool.ipam_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool) | resource |
 | [aws_vpc_ipam_pool_cidr.ipam_pool_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool_cidr) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_ec2_instance_type.arch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type) | data source |
+| [aws_route_tables.aws_private_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
 
 ## Inputs
 
@@ -229,6 +237,7 @@ In this module, we have implemented the following CIS Compliance checks for VPC:
 | <a name="input_existing_ipam_managed_cidr"></a> [existing\_ipam\_managed\_cidr](#input\_existing\_ipam\_managed\_cidr) | The existing IPAM pool CIDR | `string` | `""` | no |
 | <a name="input_flow_log_cloudwatch_log_group_kms_key_arn"></a> [flow\_log\_cloudwatch\_log\_group\_kms\_key\_arn](#input\_flow\_log\_cloudwatch\_log\_group\_kms\_key\_arn) | The ARN of the KMS Key to use when encrypting log data for VPC flow logs | `string` | `null` | no |
 | <a name="input_flow_log_cloudwatch_log_group_retention_in_days"></a> [flow\_log\_cloudwatch\_log\_group\_retention\_in\_days](#input\_flow\_log\_cloudwatch\_log\_group\_retention\_in\_days) | Specifies the number of days you want to retain log events in the specified log group for VPC flow logs. | `number` | `null` | no |
+| <a name="input_flow_log_cloudwatch_log_group_skip_destroy"></a> [flow\_log\_cloudwatch\_log\_group\_skip\_destroy](#input\_flow\_log\_cloudwatch\_log\_group\_skip\_destroy) | Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state | `bool` | `false` | no |
 | <a name="input_flow_log_enabled"></a> [flow\_log\_enabled](#input\_flow\_log\_enabled) | Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_flow_log_max_aggregation_interval"></a> [flow\_log\_max\_aggregation\_interval](#input\_flow\_log\_max\_aggregation\_interval) | The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. Valid Values: `60` seconds or `600` seconds. | `number` | `60` | no |
 | <a name="input_intra_subnet_assign_ipv6_address_on_creation"></a> [intra\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_intra\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on intra subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
@@ -251,6 +260,8 @@ In this module, we have implemented the following CIS Compliance checks for VPC:
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of the secondary CIDR blocks which can be at most 5 | `list(string)` | `[]` | no |
 | <a name="input_secondry_cidr_enabled"></a> [secondry\_cidr\_enabled](#input\_secondry\_cidr\_enabled) | Whether enable secondary CIDR with VPC | `bool` | `false` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The CIDR block of the VPC | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_vpc_ecr_endpoint_enabled"></a> [vpc\_ecr\_endpoint\_enabled](#input\_vpc\_ecr\_endpoint\_enabled) | Set to true if you want to enable vpc ecr endpoints | `bool` | `false` | no |
+| <a name="input_vpc_s3_endpoint_enabled"></a> [vpc\_s3\_endpoint\_enabled](#input\_vpc\_s3\_endpoint\_enabled) | Set to true if you want to enable vpc S3 endpoints | `bool` | `false` | no |
 | <a name="input_vpn_key_pair_name"></a> [vpn\_key\_pair\_name](#input\_vpn\_key\_pair\_name) | Specify the name of AWS Keypair to be used for VPN Server | `string` | `""` | no |
 | <a name="input_vpn_server_enabled"></a> [vpn\_server\_enabled](#input\_vpn\_server\_enabled) | Set to true if you want to deploy VPN Gateway resource and attach it to the VPC | `bool` | `false` | no |
 | <a name="input_vpn_server_instance_type"></a> [vpn\_server\_instance\_type](#input\_vpn\_server\_instance\_type) | EC2 instance Type for VPN Server, Only amd64 based instance type are supported eg. t2.medium, t3.micro, c5a.large etc. | `string` | `"t3a.small"` | no |

--- a/examples/complete-vpc-with-vpn/README.md
+++ b/examples/complete-vpc-with-vpn/README.md
@@ -25,18 +25,23 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_key_pair_vpn"></a> [key\_pair\_vpn](#module\_key\_pair\_vpn) | squareops/keypair/aws | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | squareops/vpc/aws | n/a |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/complete-vpc-with-vpn/main.tf
+++ b/examples/complete-vpc-with-vpn/main.tf
@@ -1,7 +1,7 @@
 locals {
-  name        = "vpc"
+  name        = "vpcp"
   region      = "ap-south-1"
-  environment = "prod"
+  environment = "prodd"
   additional_aws_tags = {
     Owner      = "Organization_Name"
     Expires    = "Never"

--- a/examples/complete-vpc-with-vpn/main.tf
+++ b/examples/complete-vpc-with-vpn/main.tf
@@ -7,8 +7,12 @@ locals {
     Expires    = "Never"
     Department = "Engineering"
   }
-  vpc_cidr = "10.10.0.0/16"
+  kms_user         = null
+  vpc_cidr         = "10.10.0.0/16"
+  current_identity = data.aws_caller_identity.current.arn
 }
+
+data "aws_caller_identity" "current" {}
 
 module "key_pair_vpn" {
   source             = "squareops/keypair/aws"
@@ -17,14 +21,62 @@ module "key_pair_vpn" {
   ssm_parameter_path = format("%s-%s-vpn", local.environment, local.name)
 }
 
+module "kms" {
+  source = "terraform-aws-modules/kms/aws"
+
+  deletion_window_in_days = 7
+  description             = "Symetric Key to Enable Encryption at rest using KMS services."
+  enable_key_rotation     = false
+  is_enabled              = true
+  key_usage               = "ENCRYPT_DECRYPT"
+  multi_region            = false
+
+  # Policy
+  enable_default_policy                  = true
+  key_owners                             = [local.current_identity]
+  key_administrators                     = local.kms_user == null ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS", local.current_identity] : local.kms_user
+  key_users                              = local.kms_user == null ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS", local.current_identity] : local.kms_user
+  key_service_users                      = local.kms_user == null ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS", local.current_identity] : local.kms_user
+  key_symmetric_encryption_users         = [local.current_identity]
+  key_hmac_users                         = [local.current_identity]
+  key_asymmetric_public_encryption_users = [local.current_identity]
+  key_asymmetric_sign_verify_users       = [local.current_identity]
+  key_statements = [
+    {
+      sid    = "AllowCloudWatchLogsEncryption",
+      effect = "Allow"
+      actions = [
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["logs.${local.region}.amazonaws.com"]
+        }
+      ]
+    }
+  ]
+  # Aliases
+  aliases                 = ["${local.name}-KMS"]
+  aliases_use_name_prefix = true
+}
+
+
 module "vpc" {
-  source                                          = "squareops/vpc/aws"
+  source                                          = "../../"
   name                                            = local.name
+  region                                          = local.region
   vpc_cidr                                        = local.vpc_cidr
   environment                                     = local.environment
-  flow_log_enabled                                = false
+  flow_log_enabled                                = true
   vpn_key_pair_name                               = module.key_pair_vpn.key_pair_name
-  availability_zones                              = ["us-east-1a", "us-east-1b"]
+  availability_zones                              = ["ap-south-1a", "ap-south-1b"]
   vpn_server_enabled                              = true
   intra_subnet_enabled                            = true
   public_subnet_enabled                           = true
@@ -33,7 +85,10 @@ module "vpc" {
   one_nat_gateway_per_az                          = true
   database_subnet_enabled                         = true
   vpn_server_instance_type                        = "t3a.small"
-  flow_log_max_aggregation_interval               = 60
+  vpc_s3_endpoint_enabled                         = true
+  vpc_ecr_endpoint_enabled                        = true
+  flow_log_max_aggregation_interval               = 60 # In seconds
+  flow_log_cloudwatch_log_group_skip_destroy      = true
   flow_log_cloudwatch_log_group_retention_in_days = 90
-  flow_log_cloudwatch_log_group_kms_key_arn       = "arn:aws:kms:us-east-2:222222222222:key/kms_key_arn" #Enter your kms key arn
+  flow_log_cloudwatch_log_group_kms_key_arn       = module.kms.key_arn #Enter your kms key arn
 }

--- a/examples/complete-vpc-with-vpn/main.tf
+++ b/examples/complete-vpc-with-vpn/main.tf
@@ -1,7 +1,7 @@
 locals {
-  name        = "vpcp"
+  name        = "vpc"
   region      = "ap-south-1"
-  environment = "prodd"
+  environment = "prod"
   additional_aws_tags = {
     Owner      = "Organization_Name"
     Expires    = "Never"
@@ -69,7 +69,7 @@ module "kms" {
 
 
 module "vpc" {
-  source                                          = "../../"
+  source                                          = "squareops/vpc/aws"
   name                                            = local.name
   region                                          = local.region
   vpc_cidr                                        = local.vpc_cidr

--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,7 @@ resource "aws_vpc_endpoint" "private-s3" {
   depends_on        = [data.aws_route_tables.aws_private_routes]
   vpc_id            = module.vpc.vpc_id
   service_name      = "com.amazonaws.${var.region}.s3"
-  route_table_ids   = data.aws_route_tables.aws_private_routes.ids
+  route_table_ids   = data.aws_route_tables.aws_private_routes[0].ids
   vpc_endpoint_type = "Gateway"
   policy            = <<POLICY
 {
@@ -257,11 +257,11 @@ resource "aws_security_group" "vpc_endpoints" {
   vpc_id      = module.vpc.vpc_id
 
   ingress {
-    description     = "Allow Nodes to pull images from ECR via VPC endpoints"
-    protocol        = "tcp"
-    from_port       = 443
-    to_port         = 443
-    security_groups = [module.vpc.default_security_group_id]
+    description = "Allow Nodes to pull images from ECR via VPC endpoints"
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = [var.vpc_cidr]
   }
 }
 # private links for ECR.dkr
@@ -272,7 +272,7 @@ resource "aws_vpc_endpoint" "private-ecr-dkr" {
   vpc_id              = module.vpc.vpc_id
   service_name        = "com.amazonaws.${var.region}.ecr.dkr"
   subnet_ids          = module.vpc.private_subnets
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   policy              = <<POLICY

--- a/variables.tf
+++ b/variables.tf
@@ -263,3 +263,21 @@ variable "existing_ipam_managed_cidr" {
   default     = ""
   type        = string
 }
+
+variable "flow_log_cloudwatch_log_group_skip_destroy" {
+  description = " Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_s3_endpoint_enabled" {
+  description = "Set to true if you want to enable vpc S3 endpoints"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_ecr_endpoint_enabled" {
+  description = "Set to true if you want to enable vpc ecr endpoints"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
**Release Note:**

**New Features**
VPC Flow Log Management:
**New Variable**: flow_log_cloudwatch_log_group_skip_destroy
This release introduces a new variable, **flow_log_cloudwatch_log_group_skip_destroy**, allowing you to control whether the CloudWatch log group associated with VPC flow logs should be destroyed during Terraform destroy. Set this flag to true if you want to skip the destruction of the log group, preserving your log data.

Private Links for AWS Services
Amazon S3 Private Links:
**New Variable**: vpc_s3_endpoint_enabled
Enable or disable the creation of VPC Endpoints for Amazon S3. When set to true, this feature enables private connectivity to Amazon S3 from within your VPC.

Amazon ECR Private Links:
**New Variable**: vpc_ecr_endpoint_enabled
Enable or disable the creation of VPC Endpoints for Amazon Elastic Container Registry (ECR). When set to true, this feature allows your resources within the VPC to access ECR privately.