### PR TITLE
Stop using deprecated template_file (use templatefile instead)

### DIFF
--- a/modules/vpn/README.md
+++ b/modules/vpn/README.md
@@ -17,7 +17,6 @@ Refer [this](https://pritunl.com/) for more information.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.23 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.2.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ## Providers

--- a/modules/vpn/README.md
+++ b/modules/vpn/README.md
@@ -53,7 +53,7 @@ Refer [this](https://pritunl.com/) for more information.
 | [aws_iam_policy.SSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy.SecretsManagerReadWrite](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [template_file.pritunl](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [templatefile.pritunl](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -87,7 +87,7 @@ module "vpn_server" {
   key_name                    = var.vpn_key_pair
   associate_public_ip_address = true
   vpc_security_group_ids      = [module.security_group_vpn.security_group_id]
-  user_data                   = templatefile("${path.module}/scripts/pritunl-vpn.sh")
+  user_data                   = templatefile("${path.module}/scripts/pritunl-vpn.sh", {})
   iam_instance_profile        = join("", aws_iam_instance_profile.vpn_SSM[*].name)
 
 

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -75,7 +75,7 @@ data "aws_ami" "ubuntu_20_ami" {
 }
 
 
-data "template_file" "pritunl" {
+data "templatefile" "pritunl" {
   template = file("${path.module}/scripts/pritunl-vpn.sh")
 }
 

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -75,10 +75,6 @@ data "aws_ami" "ubuntu_20_ami" {
 }
 
 
-data "templatefile" "pritunl" {
-  template = file("${path.module}/scripts/pritunl-vpn.sh")
-}
-
 data "aws_region" "current" {}
 
 module "vpn_server" {
@@ -91,7 +87,7 @@ module "vpn_server" {
   key_name                    = var.vpn_key_pair
   associate_public_ip_address = true
   vpc_security_group_ids      = [module.security_group_vpn.security_group_id]
-  user_data                   = join("", data.template_file.pritunl[*].rendered)
+  user_data                   = templatefile("${path.module}/scripts/pritunl-vpn.sh")
   iam_instance_profile        = join("", aws_iam_instance_profile.vpn_SSM[*].name)
 
 

--- a/modules/vpn/versions.tf
+++ b/modules/vpn/versions.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.9.1"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2.0"
-    }
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.23"


### PR DESCRIPTION
When running on my M1 Mac, I was getting the following error:

```
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
│
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of
│ this provider may have different platforms supported.
```

This PR stops the error by moving away from the deprecated template_file to templatefile.