### PR TITLE
Add cost related tags in additional_aws_tags in all calling modules

### DIFF
--- a/examples/complete-vpc-with-vpn/main.tf
+++ b/examples/complete-vpc-with-vpn/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "Organization_Name"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   kms_user           = null
   vpc_cidr           = "10.10.0.0/16"

--- a/examples/ipam-managed-vpc/main.tf
+++ b/examples/ipam-managed-vpc/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "SquareOps"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   vpc_cidr     = "10.10.0.0/16"
   ipam_enabled = true

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "SquareOps"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   vpc_cidr           = "10.10.0.0/16"
   availability_zones = ["us-east-1a", "us-east-1b"]

--- a/examples/vpc-dualstack/main.tf
+++ b/examples/vpc-dualstack/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "SquareOps"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   vpc_cidr           = "10.10.0.0/16"
   availability_zones = ["us-east-1a", "us-east-1b"]

--- a/examples/vpc-native-ipv6/main.tf
+++ b/examples/vpc-native-ipv6/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "SquareOps"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   vpc_cidr           = "10.10.0.0/16"
   availability_zones = ["us-east-1a", "us-east-1b"]

--- a/examples/vpc-with-peering/main.tf
+++ b/examples/vpc-with-peering/main.tf
@@ -8,6 +8,8 @@ locals {
   additional_tags = {
     Owner   = "tenent"
     Tenancy = "dedicated"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
 }
 

--- a/examples/vpc-with-private-subnet/main.tf
+++ b/examples/vpc-with-private-subnet/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "SquareOps"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   vpc_cidr           = "10.10.0.0/16"
   availability_zones = ["us-east-1a", "us-east-1b"]

--- a/examples/vpc-with-secondary-cidr/main.tf
+++ b/examples/vpc-with-secondary-cidr/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "SquareOps"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   vpc_cidr              = "10.10.0.0/16"
   availability_zones    = ["us-east-1a", "us-east-1b"]


### PR DESCRIPTION
**1.  Add the following cost tags to the additional_aws_tags in all calling module:**

**Product = "Atmosly"
Environment = local.environment**

These are the calling modules where the cost related tags added.
1. Complete vpc with vpn
2. ipam-managed-vpc
3. simple-vpc
4. vpc-dualstack
5. vpc-native-ipv6
6. vpc-with-peering
7. vpc-with-private-subnet
8. vpc-with-secondary-cidr